### PR TITLE
Added resume_polling method to CirqSimulator class.

### DIFF
--- a/floq/client/simulators/cirq.py
+++ b/floq/client/simulators/cirq.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Union
 import cirq
 import numpy as np
 
-from .. import schemas
+from .. import errors, schemas
 from . import floq
 
 
@@ -191,3 +191,23 @@ class CirqSimulator(
             )
             for param_resolver in cirq.to_resolvers(params)
         ]
+
+    def resume_polling(self) -> Any:
+        """Resumes job pooling.
+
+        If the previous polling attempt failed due to TimeoutError, calling this
+        function will result in resuming polling until job finished execution.
+
+        Returns:
+            Simulation job results.
+
+        Raises:
+            ResumePollingError if no job have been previously queried.
+            SimulationError if the job failed.
+            TimeoutError if the job has not finished within given time limit.
+        """
+        sim = next((x for x in self._simulators.values() if x.can_resume_polling), None)
+        if sim is None:
+            raise errors.ResumePollingError()
+
+        return sim.resume_polling()

--- a/floq/client/simulators/floq.py
+++ b/floq/client/simulators/floq.py
@@ -62,6 +62,11 @@ class AbstractRemoteSimulator(abc.ABC):
         self._job_id: Optional[uuid.UUID] = None
         self._results_schema = schema
 
+    @property
+    def can_resume_polling(self) -> bool:
+        """Indicates if can resume polling job results."""
+        return self._job_id is not None
+
     def resume_polling(self, timeout: int = _TIMEOUT) -> Any:
         """Resumes job pooling.
 
@@ -72,13 +77,16 @@ class AbstractRemoteSimulator(abc.ABC):
             timeout: Maximum number of seconds to wait for simulation to
             complete.
 
+        Returns:
+            Simulation job results or None if cannot resume polling.
+
         Raises:
             ResumePollingError if no job have been previously queried.
             SimulationError if the job failed.
             TimeoutError if the job has not finished within given time limit.
         """
-        if not self._job_id:
-            raise errors.ResumePollingError()
+        if not self.can_resume_polling:
+            return None
 
         return self._poll_results(timeout)
 

--- a/test/simulators/test_cirq.py
+++ b/test/simulators/test_cirq.py
@@ -17,7 +17,7 @@ import unittest
 import unittest.mock
 import cirq
 
-from floq.client import containers, schemas, simulators
+from floq.client import containers, errors, schemas, simulators
 
 
 # TODO(b/191300572): Add the follow run method tests
@@ -97,3 +97,28 @@ class TestCirqSimulator(unittest.TestCase):
         self.mocked_simulator.run.assert_called_once_with(
             circuit, cirq.ParamResolver(None), observables
         )
+
+    def test_resume_polling(self) -> None:
+        """Tests resume_polling method behavior."""
+        # Test setup
+        self.mocked_simulator.can_resume_polling = True
+        self.mocked_simulator.resume_polling.return_value = None
+
+        # Run test
+        result = self.simulator.resume_polling()
+
+        # Verification
+        self.assertIsNone(result)
+        self.mocked_simulator.resume_polling.assert_called_once()
+
+    def test_resume_polling_no_previous_job(self) -> None:
+        """Tests resume_polling method behavior: current job is unset"""
+        # Test setup
+        self.mocked_simulator.can_resume_polling = False
+
+        # Run test
+        with self.assertRaises(errors.ResumePollingError):
+            self.simulator.resume_polling()
+
+        # Verification
+        self.mocked_simulator.resume_polling.assert_not_called()

--- a/test/simulators/test_floq.py
+++ b/test/simulators/test_floq.py
@@ -237,12 +237,6 @@ class TestSamplesSimulator(TestRemoteSimulator):
         ]
         self.assertEqual(self.mocked_sleep.call_args_list, call_args_list)
 
-    def test_resume_polling_error(self) -> None:
-        """Tests resume_polling method behavior: no previous job id."""
-        # Run test
-        with self.assertRaises(errors.ResumePollingError):
-            self.simulator.resume_polling()
-
     def test_serialization_error(self) -> None:
         """Tests serialization error."""
         with self.assertRaises(errors.SerializationError):


### PR DESCRIPTION
This commit adds missing resume_polling method to the CirqSimulator that resumes polling job results for the last submitted quantum circuit. 