### PR TITLE
Add PennyLane + Floq tutorial

### DIFF
--- a/docs/PennyLane_Cirq_with_Floq_Tutorial.ipynb
+++ b/docs/PennyLane_Cirq_with_Floq_Tutorial.ipynb
@@ -1,0 +1,143 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "PennyLane-Cirq with Floq Tutorial.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "5sAFtvqiiM3t"
+      },
+      "source": [
+        "Copyright 2021 Floq authors.\n",
+        "\n",
+        "Licensed under the Apache License, Version 2.0 (the \"License\");"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "QAIEPJm3iY50"
+      },
+      "source": [
+        "#@title Copyright 2021 Floq authors, All Rights Reserved.\n",
+        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-sSF6cwjia-s"
+      },
+      "source": [
+        "In this tutorial, we introduce how to use Pennylane with Floq backend. Please make sure that the versions of all libraries should match for the successful execution."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "D10rprCSRac3",
+        "outputId": "e3201f1d-dada-4b2c-af3b-662e6d45fabc"
+      },
+      "source": [
+        "!pip install pennylane==0.14.0 --quiet\n",
+        "!pip install pennylane-cirq==0.14.0 --quiet\n",
+        "!pip install floq-client==0.1.1 --quiet\n",
+        "!pip install cirq==0.10.0 --quiet"
+      ],
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "\u001b[K     |████████████████████████████████| 481kB 8.3MB/s \n",
+            "\u001b[K     |████████████████████████████████| 1.5MB 7.8MB/s \n",
+            "\u001b[K     |████████████████████████████████| 389kB 42.8MB/s \n",
+            "\u001b[K     |████████████████████████████████| 1.3MB 42.7MB/s \n",
+            "\u001b[K     |████████████████████████████████| 51kB 4.0MB/s \n",
+            "\u001b[K     |████████████████████████████████| 1.8MB 14.8MB/s \n",
+            "\u001b[K     |████████████████████████████████| 61kB 7.7MB/s \n",
+            "\u001b[K     |████████████████████████████████| 51kB 6.3MB/s \n",
+            "\u001b[K     |████████████████████████████████| 3.2MB 31.4MB/s \n",
+            "\u001b[31mERROR: google-colab 1.0.0 has requirement requests~=2.23.0, but you'll have requests 2.25.1 which is incompatible.\u001b[0m\n",
+            "\u001b[31mERROR: datascience 0.10.6 has requirement folium==0.2.1, but you'll have folium 0.8.3 which is incompatible.\u001b[0m\n",
+            "\u001b[?25h"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "__kLfziVXIOV",
+        "outputId": "aed5c9d8-4ea7-41d8-cc32-744ec6248a5b"
+      },
+      "source": [
+        "import floq.client\n",
+        "import pennylane as qml\n",
+        "import numpy as np\n",
+        "import sys\n",
+        "\n",
+        "wires = 26  # The minimum number of qubits is 26 for Floq.\n",
+        "np.random.seed(0)\n",
+        "\n",
+        "weights = np.random.randn(1, wires, 3)\n",
+        "API_KEY = \"YOUR_API_KEY\"\n",
+        "client = floq.client.CirqClient(API_KEY)\n",
+        "sim = client.simulator\n",
+        "\n",
+        "dev = qml.device(\"cirq.simulator\", wires=wires, simulator=sim, analytic=False)\n",
+        "# dev = qml.device(\"cirq.simulator\", wires=wires, analytic=False)\n",
+        "\n",
+        "@qml.qnode(dev)\n",
+        "def my_circuit(weights):\n",
+        "\tqml.templates.layers.StronglyEntanglingLayers(weights, wires=range(wires))\n",
+        "\treturn qml.expval(qml.PauliZ(0))\n",
+        "\n",
+        "print(my_circuit(weights))"
+      ],
+      "execution_count": 10,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "6.2515027821064e-08\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #8

The appropriate `cirq`, `pennylane` and `pennylane-cirq` versions as well as the order `pip install [packages]` should match.